### PR TITLE
Fix missing architecture mapping "arm64"

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -56,6 +56,9 @@ download_release() {
   "aarch64")
     arch="arm64"
     ;;
+  "arm64")
+    arch="arm64"
+    ;;
   esac
 
   asset="kubelogin-${platform}-${arch}.zip"


### PR DESCRIPTION
At least my mac (Macbook Pro something) says, it's an arm64, not aarch64

```
uname; uname -m
Darwin
arm64
```

Worth to note, that I am usually a Linux-guy and I have no idea about Macs :)